### PR TITLE
Update to latest LCM CMake infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(robotlocomotion-lcmtypes)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.1)
 
 include(CMakePackageConfigHelpers)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 project(robotlocomotion-lcmtypes)
 cmake_minimum_required(VERSION 2.8.12)
 
+include(CMakePackageConfigHelpers)
+
+find_package(PythonInterp)
+find_package(Java)
+
+if(JAVA_FOUND)
+  include(UseJava)
+endif()
+
 # TODO remove when minimum CMake >= 3.7
 if(CMAKE_VERSION VERSION_LESS 3.7)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,22 @@ project(robotlocomotion-lcmtypes)
 cmake_minimum_required(VERSION 3.1)
 
 include(CMakePackageConfigHelpers)
+include(GenerateExportHeader)
 
 find_package(PythonInterp)
 find_package(Java)
 
 if(JAVA_FOUND)
   include(UseJava)
+endif()
+
+# Enable ELF hidden visibility
+set(CMAKE_C_VISIBILITY_PRESET "hidden")
+set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
 endif()
 
 # TODO remove when minimum CMake >= 3.7

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(Java)
 if(NOT JAVA_FOUND)
   message(STATUS "Java not found: not building Java LCM-SPY plugins")
   return()
@@ -9,7 +8,6 @@ if(NOT TARGET lcm-java)
 endif()
 
 message(STATUS "Found Java and lcm-java: building Java LCM-SPY plugins")
-include(UseJava)
 
 set(src_dir ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(jar_fname lcmspy_plugins_robotlocomotion.jar)

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -58,20 +58,19 @@ lcm_wrap_types(
   viewer_load_robot_t.lcm
 )
 
-add_library(robotlocomotion-lcmtypes ${c_sources})
+lcm_add_library(robotlocomotion-lcmtypes C ${c_sources} ${c_install_headers})
 target_include_directories(robotlocomotion-lcmtypes INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-target_link_libraries(robotlocomotion-lcmtypes lcm)
+
+lcm_add_library(robotlocomotion-lcmtypes-cpp CPP ${cpp_install_headers})
+target_include_directories(robotlocomotion-lcmtypes-cpp INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 lcm_install_headers(
   ${c_install_headers}
   ${cpp_install_headers}
   DESTINATION include/lcmtypes
 )
-
-add_library(robotlocomotion-lcmtypes-cpp INTERFACE)
-target_include_directories(robotlocomotion-lcmtypes-cpp INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 install(TARGETS robotlocomotion-lcmtypes robotlocomotion-lcmtypes-cpp
   EXPORT ${PROJECT_NAME}Targets

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -17,7 +17,7 @@ if(JAVA_FOUND)
 endif()
 
 lcm_wrap_types(
-  C_SOURCES sources
+  C_SOURCES c_sources
   C_HEADERS c_install_headers
   CPP_HEADERS cpp_install_headers
   CREATE_C_AGGREGATE_HEADER
@@ -63,7 +63,7 @@ lcm_wrap_types(
   viewer_load_robot_t.lcm
 )
 
-add_library(robotlocomotion-lcmtypes ${sources})
+add_library(robotlocomotion-lcmtypes ${c_sources})
 target_include_directories(robotlocomotion-lcmtypes INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 target_link_libraries(robotlocomotion-lcmtypes lcm)

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 if(PYTHONINTERP_FOUND)
   set(python_args PYTHON_SOURCES python_install_sources)
 endif()
-if(JAVA_FOUND)
+if(JAVA_FOUND AND TARGET lcm-java)
   set(java_args JAVA_SOURCES java_sources)
 endif()
 
@@ -86,28 +86,30 @@ if(PYTHONINTERP_FOUND)
 endif()
 
 if(JAVA_FOUND)
-  include(UseJava)
+  if(NOT TARGET lcm-java)
+    message(STATUS "lcm-java not found: not building Java LCM type bindings")
+  else()
+    add_jar(robotlocomotion-lcmtypes-jar
+      OUTPUT_NAME robotlocomotion-lcmtypes
+      INCLUDE_JARS lcm-java
+      SOURCES ${java_sources}
+    )
 
-  add_jar(robotlocomotion-lcmtypes-jar
-    OUTPUT_NAME robotlocomotion-lcmtypes
-    INCLUDE_JARS lcm-java
-    SOURCES ${java_sources}
-  )
+    install_jar(robotlocomotion-lcmtypes-jar share/java)
 
-  install_jar(robotlocomotion-lcmtypes-jar share/java)
-
-  set(ROBOTLOCOMOTION-LCMTYPES_INCLUDE_JAVA
-    "include(\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}JavaTargets.cmake)"
-  )
-  export_jars(
-    FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}JavaTargets.cmake
-    TARGETS robotlocomotion-lcmtypes-jar
-  )
-  install_jar_exports(
-    FILE ${PROJECT_NAME}JavaTargets.cmake
-    DESTINATION ${CONFIG_INSTALL_DIR}
-    TARGETS robotlocomotion-lcmtypes-jar
-  )
+    set(ROBOTLOCOMOTION-LCMTYPES_INCLUDE_JAVA
+      "include(\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}JavaTargets.cmake)"
+    )
+    export_jars(
+      FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}JavaTargets.cmake
+      TARGETS robotlocomotion-lcmtypes-jar
+    )
+    install_jar_exports(
+      FILE ${PROJECT_NAME}JavaTargets.cmake
+      DESTINATION ${CONFIG_INSTALL_DIR}
+      TARGETS robotlocomotion-lcmtypes-jar
+    )
+  endif()
 endif()
 
 configure_package_config_file(

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -12,6 +12,7 @@ if(JAVA_FOUND AND TARGET lcm-java)
 endif()
 
 lcm_wrap_types(
+  C_EXPORT robotlocomotion_lcmtypes
   C_SOURCES c_sources
   C_HEADERS c_install_headers
   CPP_HEADERS cpp_install_headers
@@ -59,6 +60,8 @@ lcm_wrap_types(
 )
 
 lcm_add_library(robotlocomotion-lcmtypes C ${c_sources} ${c_install_headers})
+generate_export_header(robotlocomotion-lcmtypes
+  BASE_NAME robotlocomotion_lcmtypes)
 target_include_directories(robotlocomotion-lcmtypes INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 

--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -1,8 +1,3 @@
-find_package(PythonInterp)
-find_package(Java)
-
-include(CMakePackageConfigHelpers)
-
 if(WIN32)
   set(CONFIG_INSTALL_DIR CMake)
 else()


### PR DESCRIPTION
Clean up the build logic somewhat, and pull in the latest goodies from upstream. In particular, we now export decorate the bindings (so shared libraries on Windows are possible, as is using ELF hidden symbol visibility, which is turned on in this PR). Also, check if `lcm-java` actually exists before trying to build the Java bindings (which require it).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/lcmtypes/4)

<!-- Reviewable:end -->
