### PR TITLE
add copies of viewer_*_t.lcm messages from drake

### DIFF
--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -29,6 +29,11 @@ lcm_wrap_types(
   support_body_t.lcm
   support_element_t.lcm
   support_sequence_t.lcm
+  viewer_command_t.lcm
+  viewer_draw_t.lcm
+  viewer_geometry_data_t.lcm
+  viewer_link_data_t.lcm
+  viewer_load_robot_t.lcm
   )
 
 

--- a/lcmtypes/viewer_command_t.lcm
+++ b/lcmtypes/viewer_command_t.lcm
@@ -1,0 +1,16 @@
+package robotlocomotion;
+
+struct viewer_command_t {
+  int8_t command_type;
+  string command_data;
+
+  // enum for viewer command type
+  const int8_t STATUS           = 0;
+  const int8_t LOAD_MODEL       = 1;
+  const int8_t LOAD_RENDERER    = 2;
+  const int8_t SHUTDOWN         = 3;
+  const int8_t START_RECORDING  = 4;
+  const int8_t STOP_RECORDING   = 5;
+  const int8_t LOAD_TERRAIN     = 6;
+  const int8_t SET_TERRAIN_TRANSFORM = 7;
+}

--- a/lcmtypes/viewer_draw_t.lcm
+++ b/lcmtypes/viewer_draw_t.lcm
@@ -1,0 +1,12 @@
+package robotlocomotion;
+
+struct viewer_draw_t {
+  // The timestamp in milliseconds.
+  int64_t timestamp;
+
+  int32_t num_links;
+  string link_name[num_links];
+  int32_t robot_num[num_links];
+  float position[num_links][3];
+  float quaternion[num_links][4];
+}

--- a/lcmtypes/viewer_geometry_data_t.lcm
+++ b/lcmtypes/viewer_geometry_data_t.lcm
@@ -1,0 +1,23 @@
+package robotlocomotion;
+
+struct viewer_geometry_data_t {
+  int8_t type;
+
+  // Defines an enum for geometry type.
+  const int8_t BOX          = 1;
+  const int8_t SPHERE       = 2;
+  const int8_t CYLINDER     = 3;
+  const int8_t MESH         = 4;
+  const int8_t CAPSULE      = 5;
+  const int8_t ELLIPSOID    = 6;
+
+
+  float position[3];
+  float quaternion[4];
+  float color[4];
+
+  string string_data;
+
+  int32_t num_float_data;
+  float float_data[num_float_data];
+}

--- a/lcmtypes/viewer_link_data_t.lcm
+++ b/lcmtypes/viewer_link_data_t.lcm
@@ -1,0 +1,9 @@
+package robotlocomotion;
+
+struct viewer_link_data_t {
+  string name;
+  int32_t robot_num;
+
+  int32_t num_geom;
+  viewer_geometry_data_t geom[num_geom];
+}

--- a/lcmtypes/viewer_load_robot_t.lcm
+++ b/lcmtypes/viewer_load_robot_t.lcm
@@ -1,0 +1,6 @@
+package robotlocomotion;
+
+struct viewer_load_robot_t {
+  int32_t num_links;
+  viewer_link_data_t link[num_links];
+}


### PR DESCRIPTION
These messages implement the drawing protocol between drake and
drake-visualizer.  The messages are currently in drake, but the plan
is to remove them from there so that they are only in this repository.

Note, these messages are also in bot_core_lcmtypes.  We are waiting on
openhumanoids and drake to begin using this robotlocomotion/lcmtypes repo.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/lcmtypes/7)

<!-- Reviewable:end -->
