### PR TITLE
Add LCM types for point, quaternion, pose, header and pose_stamped

### DIFF
--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -20,9 +20,14 @@ lcm_wrap_types(
   CREATE_CPP_AGGREGATE_HEADER
   ${python_args}
   ${java_args}
+  header_t.lcm
   grasp_transition_state_t.lcm
   plan_control_t.lcm
   plan_status_t.lcm
+  point_t.lcm
+  pose_t.lcm
+  pose_stamped_t.lcm
+  quaternion_t.lcm
   residual_observer_state_t.lcm
   robot_plan_t.lcm
   robot_plan_with_supports_t.lcm

--- a/lcmtypes/header_t.lcm
+++ b/lcmtypes/header_t.lcm
@@ -1,0 +1,13 @@
+package robotlocomotion;
+
+// This holds timestamp and a particular coordinate frame.
+// This follows ROS's convention except the timestamp since
+// utime has been widely used in Drake LCM.
+struct header_t {
+  // Sequence ID: consecutively increasing ID.
+  int32_t seq;
+  // Timestamp in microseconds.
+  int64_t utime;
+  // The name of a frame this data is associated with.
+  string frame_name;
+}

--- a/lcmtypes/point_t.lcm
+++ b/lcmtypes/point_t.lcm
@@ -1,0 +1,8 @@
+package robotlocomotion;
+
+// A representation of a 3D point.
+struct point_t {
+  double x;
+  double y;
+  double z;
+}

--- a/lcmtypes/pose_stamped_t.lcm
+++ b/lcmtypes/pose_stamped_t.lcm
@@ -1,0 +1,7 @@
+package robotlocomotion;
+
+// A representation of a 3D pose with timestamp and associated frame name.
+struct pose_stamped_t {
+  header_t header;
+  pose_t pose;
+}

--- a/lcmtypes/pose_t.lcm
+++ b/lcmtypes/pose_t.lcm
@@ -1,0 +1,7 @@
+package robotlocomotion;
+
+// A representation of a 3D pose.
+struct pose_t {
+  point_t position;
+  quaternion_t orientation;
+}

--- a/lcmtypes/quaternion_t.lcm
+++ b/lcmtypes/quaternion_t.lcm
@@ -1,0 +1,9 @@
+package robotlocomotion;
+
+// A representation of an orientation in quaternion.
+struct quaternion_t {
+  double w;
+  double x;
+  double y;
+  double z;
+}


### PR DESCRIPTION
Based-on the [discussion](https://github.com/RobotLocomotion/drake/pull/6155), I'm putting these lcmtypes here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/lcmtypes/12)
<!-- Reviewable:end -->
