### PR TITLE
Add image related LCM types

### DIFF
--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -21,6 +21,8 @@ lcm_wrap_types(
   ${python_args}
   ${java_args}
   header_t.lcm
+  image_array_t.lcm
+  image_t.lcm
   grasp_transition_state_t.lcm
   plan_control_t.lcm
   plan_status_t.lcm

--- a/lcmtypes/image_array_t.lcm
+++ b/lcmtypes/image_array_t.lcm
@@ -3,7 +3,7 @@ package robotlocomotion;
 // This is used for sending and/or receiving multiple images at the same time.
 struct image_array_t {
   // The timestamp and the frame name.
-  // The timestamp holds when this data is packed. It's convinient to store
+  // The timestamp holds when this data is packed. It's convenient to store
   // the latest timestamp among the timestamps in `images` since it is possible
   // for each of `images` having different timestamps if their camera's shutters
   // are not synchronized.

--- a/lcmtypes/image_array_t.lcm
+++ b/lcmtypes/image_array_t.lcm
@@ -1,0 +1,19 @@
+package robotlocomotion;
+
+// This is used for sending and/or receiving multiple images at the same time.
+struct image_array_t {
+  // The timestamp and the frame name.
+  // The timestamp holds when this data is packed. It's convinient to store
+  // the latest timestamp among the timestamps in `images` since it is possible
+  // for each of `images` having different timestamps if their camera's shutters
+  // are not synchronized.
+  // The `frame_name` can be empty if each image_t in `images` contains the
+  // information in it.
+  header_t header;
+
+  // The number of images.
+  int32_t num_images;
+
+  // An array of image_t.
+  image_t images[num_images];
+}

--- a/lcmtypes/image_t.lcm
+++ b/lcmtypes/image_t.lcm
@@ -32,7 +32,7 @@ struct image_t {
   // The compression method.
   int8_t compression_method;
 
-  // enum for pixel_format. Add other formats as needed.
+  // enum for pixel_format.
   const int8_t PIXEL_FORMAT_GRAY       = 0;
   const int8_t PIXEL_FORMAT_RGB        = 1;
   const int8_t PIXEL_FORMAT_BGR        = 2;
@@ -48,7 +48,7 @@ struct image_t {
   const int8_t PIXEL_FORMAT_BAYER_GRBG = 12;
   const int8_t PIXEL_FORMAT_INVALID    = -1;
 
-  // enum for channel_type. Add other types as needed.
+  // enum for channel_type.
   const int8_t CHANNEL_TYPE_INT8    = 0;
   const int8_t CHANNEL_TYPE_UINT8   = 1;
   const int8_t CHANNEL_TYPE_INT16   = 2;
@@ -59,7 +59,7 @@ struct image_t {
   const int8_t CHANNEL_TYPE_FLOAT64 = 7;
   const int8_t CHANNEL_TYPE_INVALID = -1;
 
-  // enum for compression_method. Add other methods as needed.
+  // enum for compression_method.
   const int8_t COMPRESSION_METHOD_NOT_COMPRESSED = 0;
   const int8_t COMPRESSION_METHOD_ZLIB           = 1;
   const int8_t COMPRESSION_METHOD_JPEG           = 2;

--- a/lcmtypes/image_t.lcm
+++ b/lcmtypes/image_t.lcm
@@ -1,0 +1,68 @@
+package robotlocomotion;
+
+// A representation of an image.
+struct image_t {
+  // The timestamp and the frame name where this image is obtained.
+  header_t header;
+
+  // The image width in pixels.
+  int32_t width;
+
+  // The image height in pixels.
+  int32_t height;
+
+  // The physical memory size per a single row in bytes.
+  int32_t row_stride;
+
+  // The size of `data` in bytes.
+  int32_t size;
+
+  // The data that contains actual image.
+  byte data[size];
+
+  // The boolean to denote if the data is stored in the bigendian order.
+  boolean bigendian;
+
+  // The semantic meaning of pixels.
+  int8_t pixel_format;
+
+  // The data type for a channel.
+  int8_t channel_type;
+
+  // The compression method.
+  int8_t compression_method;
+
+  // enum for pixel_format. Add other formats as needed.
+  const int8_t PIXEL_FORMAT_GRAY       = 0;
+  const int8_t PIXEL_FORMAT_RGB        = 1;
+  const int8_t PIXEL_FORMAT_BGR        = 2;
+  const int8_t PIXEL_FORMAT_RGBA       = 3;
+  const int8_t PIXEL_FORMAT_BGRA       = 4;
+  const int8_t PIXEL_FORMAT_DEPTH      = 5;
+  const int8_t PIXEL_FORMAT_LABEL      = 6;
+  const int8_t PIXEL_FORMAT_MASK       = 7;
+  const int8_t PIXEL_FORMAT_DISPARITY  = 8;
+  const int8_t PIXEL_FORMAT_BAYER_BGGR = 9;
+  const int8_t PIXEL_FORMAT_BAYER_RGGB = 10;
+  const int8_t PIXEL_FORMAT_BAYER_GBRG = 11;
+  const int8_t PIXEL_FORMAT_BAYER_GRBG = 12;
+  const int8_t PIXEL_FORMAT_INVALID    = -1;
+
+  // enum for channel_type. Add other types as needed.
+  const int8_t CHANNEL_TYPE_INT8    = 0;
+  const int8_t CHANNEL_TYPE_UINT8   = 1;
+  const int8_t CHANNEL_TYPE_INT16   = 2;
+  const int8_t CHANNEL_TYPE_UINT16  = 3;
+  const int8_t CHANNEL_TYPE_INT32   = 4;
+  const int8_t CHANNEL_TYPE_UINT32  = 5;
+  const int8_t CHANNEL_TYPE_FLOAT32 = 6;
+  const int8_t CHANNEL_TYPE_FLOAT64 = 7;
+  const int8_t CHANNEL_TYPE_INVALID = -1;
+
+  // enum for compression_method. Add other methods as needed.
+  const int8_t COMPRESSION_METHOD_NOT_COMPRESSED = 0;
+  const int8_t COMPRESSION_METHOD_ZLIB           = 1;
+  const int8_t COMPRESSION_METHOD_JPEG           = 2;
+  const int8_t COMPRESSION_METHOD_PNG            = 3;
+  const int8_t COMPRESSION_METHOD_INVALID        = -1;
+}


### PR DESCRIPTION
These lcmtypes are meant to replace [bot_core_images_t.lcm](https://github.com/openhumanoids/bot_core_lcmtypes/blob/master/lcmtypes/bot_core_images_t.lcm) and [bot_core_image_t.lcm](https://github.com/openhumanoids/bot_core_lcmtypes/blob/master/lcmtypes/bot_core_image_t.lcm).

Let me summarize the major differences I made:

**images_t** (now **image_array_t** to clearly differentiate the name from image_t)
1. Dropped `image_types` since `DISPARITY`, `MASK` and `DEPTH` related consts moved to image_t now.  Also, `LEFT` and `RIGHT` are hardware specific information and those can be specified in `header.frame_name`(see below)  inside `image_t` now.

**image_t**

1.  Added `header` so that you can specify at what frame this image is obtained. It's possible for different images to have the same `frame_name` in the `header`, e.g. an RGB image and a depth image registered onto the RGB image have the same frame name.

2. Dropped `image_metadata_t` simply because I couldn't find any particular use cases.

3. Split `pixelformat` into `pixel_format`, `channel_type`, `compression_method` and `bigendian` to reduce redundancy and clean things up.

4. Dropped some consts in `pixelformat`, e.g. UYVY, YUYV, etc. simply because I don't see any use cases yet. I'm OK to add new const with as-needed basis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/lcmtypes/13)
<!-- Reviewable:end -->
