### PR TITLE
Export targets with namespace

### DIFF
--- a/lcmtypes/CMakeLists.txt
+++ b/lcmtypes/CMakeLists.txt
@@ -114,11 +114,13 @@ configure_package_config_file(
 # Exported targets for build directory
 export(
   TARGETS robotlocomotion-lcmtypes robotlocomotion-lcmtypes-cpp
+  NAMESPACE ${PROJECT_NAME}::
   FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
 )
 
 # Exported targets for installation
 install(EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE ${PROJECT_NAME}::
   DESTINATION ${CONFIG_INSTALL_DIR}
   FILE ${PROJECT_NAME}Targets.cmake
 )


### PR DESCRIPTION
Modify how we export targets to include our namespace in the exported names. This is generally preferred, and is necessary for consistency with [CPS](https://mwoehlke.github.io/cps/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/lcmtypes/14)
<!-- Reviewable:end -->
